### PR TITLE
Sort-out logo size on OSS list

### DIFF
--- a/content/oss.md
+++ b/content/oss.md
@@ -21,7 +21,7 @@ Tanzu Community Edition (TCE) は、簡単に使い始められる Kubernetes �
 
 ## Kubernetes
 
-{{< figure src="https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png" alt=Kubernetes width=200 >}}
+{{< figure src="https://kubernetes.io/images/kubernetes-horizontal-color.png" alt=Kubernetes width=300 >}}
 [Website](https://kubernetes.io/) - [GitHub](https://github.com/kubernetes)
 
 Kubernetes はデプロイの自動化、スケーリング、コンテナ化されたアプリケーションの管理のためのオープンソースシステムです。
@@ -35,63 +35,63 @@ Buildpacks はソースコードを OCI イメージに変換するツールで�
 
 ## Harbor
 
-{{< figure src="https://goharbor.io/img/logos/harbor-horizontal-color.png" alt=Harbor width=200 >}}
+{{< figure src="https://goharbor.io/img/logos/harbor-horizontal-color.png" alt=Harbor width=300 >}}
 [Website](https://goharbor.io/) - [GitHub](https://github.com/goharbor)
 
 Harbor はオープンソースのコンテナイメージレジストリです。
 
 ## Contour
 
-{{< figure src="https://d33wubrfki0l68.cloudfront.net/b92d8706535e6f2b71f90645fe9ab7b418fb8ca8/ea52e/img/contour.svg" alt=Contour width=200 >}}
+{{< figure src="https://d33wubrfki0l68.cloudfront.net/b92d8706535e6f2b71f90645fe9ab7b418fb8ca8/ea52e/img/contour.svg" alt=Contour width=300 >}}
 [Website](https://projectcontour.io/) - [GitHub](https://github.com/projectcontour/contour)
 
 Contour はオープンソースの Kubernetes Ingress コントローラーです。
 
 ## Cluster API
 
-{{< figure src="https://cluster-api.sigs.k8s.io/images/introduction.png" alt="Cluster API" width=200 >}}
+{{< figure src="https://cluster-api.sigs.k8s.io/images/introduction.png" alt="Cluster API" width=100 >}}
 [Website](https://cluster-api.sigs.k8s.io/)
 
 Cluster API はクラスターの作成、設定、管理を行うための宣言的な Kubernetes スタイルの API を使用するための Kubernetes プロジェクトです。
 
 ## Velero
 
-{{< figure src="https://velero.io/img/Velero.svg" alt=Velero width=200 >}}
+{{< figure src="https://velero.io/img/Velero.svg" alt=Velero width=300 >}}
 [Website](https://velero.io/) - [GitHub](https://github.com/vmware-tanzu/velero)
 
 Velero は安全にバックアップ、リストアを行うためのオープンソースツールです。
 
 ## Sonobuoy
 
-{{< figure src="https://sonobuoy.io/img/sonobuoy.svg" alt=Sonobuoy width=200 >}}
+{{< figure src="https://sonobuoy.io/img/sonobuoy.svg" alt=Sonobuoy width=400 >}}
 [Website](https://sonobuoy.io/) - [GitHub](https://github.com/vmware-tanzu/sonobuoy)
 
 Sonobuoy は Kubernetes クラスタの状態を簡単に取得するための分析ツールです。
 
 ## Octant
 
-{{< figure src="https://octant.dev/img/octant.svg" alt=Octant width=200 >}}
+{{< figure src="https://octant.dev/img/octant.svg" alt=Octant width=300 >}}
 [Website](https://octant.dev/) - [GitHub](https://github.com/vmware-tanzu/octant)
 
 Octant はオープンソースの Kubernetes のための開発者のため Web インターフェースです。
 
 ## Antrea
 
-{{< figure src="https://antrea.io/img/antrea-logo.svg" alt=Antrea width=200 >}}
+{{< figure src="https://antrea.io/img/antrea-logo.svg" alt=Antrea width=300 >}}
 [Website](https://antrea.io/) - [GitHub](https://github.com/antrea-io/antrea)
 
 Antrea は Open vSwitch を活用して実装された Kubernetes ネットワークソリューションです。
 
 ## Pinniped
 
-{{< figure src="https://pinniped.dev/img/logo.svg" alt=Pinniped width=200 >}}
+{{< figure src="https://pinniped.dev/img/logo.svg" alt=Pinniped width=300 >}}
 [Website](https://pinniped.dev/) - [GitHub](https://github.com/vmware-tanzu/pinniped)
 
 Pinniped は Kubernetes のユーザー認証を提供します。
 
 ## Carvel
 
-{{< figure src="https://carvel.dev/img/logo.svg" alt=Carvel width=200 >}}
+{{< figure src="https://carvel.dev/img/logo.svg" alt=Carvel width=300 >}}
 [Website](https://carvel.dev/) - [GitHub](https://github.com/vmware-tanzu/carvel)
 
 Carvel は Kubernetes へのアプリケーションのビルド、設定、デプロイを行うためのツールです。


### PR DESCRIPTION
可能な限りロゴ + 名前が横に並んでいる画像を利用して、サイズを統一しました。

fixes #27 