### PR TITLE
remove sass property for font color inside button (#28)

### DIFF
--- a/assets/sass/_components.sass
+++ b/assets/sass/_components.sass
@@ -264,8 +264,6 @@
     margin-right: 0.5rem
     margin-left: 0.25rem
   &_content
-    a
-      color: $theme
     ul, ol
       list-style: initial
       padding: 0.5rem 1.25rem


### PR DESCRIPTION
Slack参加のボタンにおいて、文字色のスタイルが上書きされてしまいテキストが読み取れないため、
該当箇所のスタイルを変更します。